### PR TITLE
docs: draft CLAUDE.md for Claude Code

### DIFF
--- a/.cursor/rules/00-base.mdc
+++ b/.cursor/rules/00-base.mdc
@@ -34,6 +34,7 @@ If uncertain, default to BEHAVIOR_CHANGE.
 - Code compiles
 - Relevant tests updated and passing (per testing rules)
 - CI pipeline passes
+- Git workflow and PR rules in `50-ci-pipeline` followed (dedicated branch, PR into `main`)
 - No weakening of existing rules or checks
 
 ---

--- a/.cursor/rules/40-testing.mdc
+++ b/.cursor/rules/40-testing.mdc
@@ -40,6 +40,11 @@ Tests are mandatory unless explicitly exempted by change classification.
 - Fix flaky tests; never mute them
 - Prefer clarity over clever setups
 
+## Beyond happy path (HARD for BEHAVIOR_CHANGE)
+- **Success-only coverage is not enough.** Where the change introduces or affects behavior, tests MUST also cover **failure paths**, **validation errors**, and **denied / unauthorized** outcomes when those are part of the contract (for example: wrong input, missing tenant, forbidden action).
+- Add **boundary** or **edge** cases when they guard real domain or infrastructure rules (not speculative coverage).
+- Prefer naming that makes the scenario obvious (see Test Naming Convention below).
+
 ## Test Naming Convention
 - **Format**: Use `should_[expectedBehavior]_when_[condition]`.
 - **Snake Case**: Always use `snake_case` for test method names. It improves readability in test reports and IDEs.

--- a/.cursor/rules/50-ci-pipeline.mdc
+++ b/.cursor/rules/50-ci-pipeline.mdc
@@ -16,6 +16,10 @@ alwaysApply: true
 - A PR MUST NOT be merged unless all required CI checks pass.
 - Branch protection MUST enforce required status checks on the main branch.
 
+## Branch workflow (HARD)
+- Do **not** push commits directly to the protected default branch (`main`). Implement work on a **dedicated branch** created from `main` (for example `feature/…`, `fix/…`, or `chore/…`).
+- Open a PR from that branch into `main`. Treat the branch as the unit of review together with its PR.
+
 ## Local expectation (HARD where feasible)
 - Before pushing, ensure `./gradlew build` passes locally (unless not feasible due to environment limits).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Claude Code — project context (draft)
+
+> **Status:** Draft. This file gives [Claude Code](https://code.claude.com/docs) a short entry point. It intentionally **does not** duplicate `.cursor/rules` or `architecture.md` — read those for full detail.
+
+## What this repo is
+
+Opinionated **Spring Boot 3** + **Java 21** monorepo (Gradle Kotlin DSL): **platform modules** + **sample service**. Architecture is **hexagonal** (ports & adapters), with **strict immutability** in the domain, **soft multi-tenancy**, and **ArchUnit** enforcing boundaries.
+
+## Source of truth (read before larger changes)
+
+| Topic | Location |
+|--------|----------|
+| Architecture overview | [`architecture.md`](architecture.md) |
+| Architectural decisions | [`docs/adr/`](docs/adr/) |
+| IDE / Cursor rule packs (testing, JPA, CI, security, …) | [`.cursor/rules/*.mdc`](.cursor/rules/) |
+| Platform testing (Testcontainers, fixtures) | [`docs/adr/ADR-009__platform-testing-infrastructure.md`](docs/adr/ADR-009__platform-testing-infrastructure.md) |
+
+If guidance conflicts, prefer **`architecture.md`** and the relevant **ADR**, then `.cursor/rules`.
+
+## Local verification
+
+From the repo root:
+
+```bash
+./gradlew build
+```
+
+Use `./gradlew test` when iterating on tests only.
+
+## Conventions (summary)
+
+- **Root Java package:** `com.pidabrow.starter`
+- **Dependency direction:** `sample-service` → platform modules only (never the reverse)
+- **IDs:** UUID (v7 where specified in rules), not sequential public IDs in APIs
+- **Tenancy:** tenant context at the edge; do not rely on ad-hoc `WHERE` for isolation
+
+## Relationship to Cursor rules
+
+[`.cursor/rules/*.mdc`](.cursor/rules/) are written for **Cursor** but encode the same project standards. When working in the terminal, treat them as **authoritative checklists** alongside `architecture.md` — avoid restating them here to prevent drift.
+
+---
+
+*End of draft.*


### PR DESCRIPTION
Adds a short `CLAUDE.md` entry point for Claude Code in the terminal, linking to `architecture.md`, ADRs, and `.cursor/rules` without duplicating their content.

**Change type:** DOCS_ONLY

Made with [Cursor](https://cursor.com)