### PR TITLE
docs(adr): migrate ADR-001, ADR-003–011 to canonical template

### DIFF
--- a/docs/adr/ADR-001__project-scope-and-philosophy.md
+++ b/docs/adr/ADR-001__project-scope-and-philosophy.md
@@ -1,16 +1,29 @@
 # ADR-001 — Project Scope & Philosophy
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-01-31
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** <!-- TODO: fill in — not stated in original ADR -->
 
-## Context
+## Context and Problem Statement
 
 This repository is intended to serve as an opinionated Spring Boot microservice starter.
 The primary goal is to demonstrate architectural decision-making rather than business feature completeness.
 
 The project is public and serves both as a reusable starter and as a portfolio artifact.
 
-## Decision
+## Decision Drivers
+
+- Demonstrate architectural decision-making rather than business feature completeness.
+- Serve both as a reusable starter and as a portfolio artifact.
+
+## Considered Options
+
+<!-- TODO: fill in — original ADR does not list alternative options -->
+
+## Decision Outcome
 
 - The project prioritizes architectural clarity over feature richness.
 - The domain model is intentionally minimal.
@@ -18,12 +31,29 @@ The project is public and serves both as a reusable starter and as a portfolio a
 - Code generation tools (e.g. AI assistants) are used for scaffolding, not for architectural decisions.
 - Architecture is documented explicitly via ADRs.
 
-## Consequences
+### Consequences
 
-- The repository may appear “incomplete” from a feature perspective.
+**Positive**
+
 - Architectural decisions are easy to review, explain, and evolve.
 - The project is well-suited for forking and adaptation.
 
-## Notes
+**Negative**
+
+- The repository may appear "incomplete" from a feature perspective.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+<!-- TODO: fill in — original ADR does not list alternative options to compare -->
+
+## Notes for AI
 
 This ADR sets the tone for all other decisions in the repository.
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-003__event-driven-auditing-architecture.md
+++ b/docs/adr/ADR-003__event-driven-auditing-architecture.md
@@ -1,30 +1,72 @@
 # ADR-003 — Event-Driven Auditing Architecture
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-01-31
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** <!-- TODO: fill in — not stated in original ADR -->
 
-## Context
+## Context and Problem Statement
 
 Auditing is required for traceability and compliance but must not pollute domain logic.
 JPA interceptors and automatic auditing frameworks were evaluated.
 
-## Decision
+## Decision Drivers
 
-- Use application-level domain events.
-- Audit logging is append-only.
-- Audit entries are written only after transaction commit.
-- Auditing is implemented via event listeners, not persistence hooks.
-- Sensitive fields must be maskable.
+- Traceability and compliance requirements.
+- Auditing must not pollute domain logic.
 
-## Consequences
-
-- Clear separation between business logic and auditing.
-- Auditing logic is extensible and testable.
-- Slight increase in conceptual complexity due to event flow.
-
-## Alternatives Considered
+## Considered Options
 
 - Hibernate Envers.
 - JPA entity listeners.
+- Application-level domain events.
 
-Both were rejected due to implicit behavior and tight coupling to persistence.
+## Decision Outcome
+
+Chosen option: "Application-level domain events", because the alternatives (Hibernate Envers, JPA entity listeners) were rejected due to implicit behavior and tight coupling to persistence.
+
+- Use application-level domain events.
+- Auditing is implemented via event listeners, not persistence hooks.
+- Audit logging is append-only.
+
+### Consequences
+
+**Positive**
+
+- Clear separation between business logic and auditing.
+- Auditing logic is extensible and testable.
+
+**Negative**
+
+- Slight increase in conceptual complexity due to event flow.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+### Hibernate Envers
+
+- Bad, because it relies on implicit behavior and tight coupling to persistence (rejected).
+
+### JPA entity listeners
+
+- Bad, because it relies on implicit behavior and tight coupling to persistence (rejected).
+
+### Application-level domain events (chosen)
+
+- Good, because it gives a clear separation between business logic and auditing.
+- Good, because auditing logic is extensible and testable.
+- Bad, because it introduces a slight increase in conceptual complexity due to event flow.
+
+## Notes for AI
+
+- Audit entries are written only after transaction commit.
+- Sensitive fields must be maskable.
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-004__application-events-vs-jpa-interceptors.md
+++ b/docs/adr/ADR-004__application-events-vs-jpa-interceptors.md
@@ -1,28 +1,70 @@
 # ADR-004 — Application Events vs JPA Interceptors
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-01-31
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** <!-- TODO: fill in — not stated in original ADR -->
 
-## Context
+## Context and Problem Statement
 
 Cross-cutting concerns such as auditing and metrics need to react to business actions.
 JPA lifecycle callbacks provide hooks but operate at the persistence level.
 
-## Decision
+## Decision Drivers
 
-- Publish events explicitly from the application layer.
-- Do not rely on JPA entity listeners or persistence callbacks for business events.
-- Event names must reflect business intent, not technical actions.
+- Cross-cutting concerns (auditing, metrics) need to react to business actions.
+- JPA lifecycle callbacks operate at the persistence level, coupling business concerns to persistence.
 
-## Consequences
-
-- Business intent is explicit and observable.
-- Cross-cutting concerns do not leak into domain or persistence layers.
-- Requires discipline to publish events consistently.
-
-## Alternatives Considered
+## Considered Options
 
 - JPA lifecycle callbacks.
 - Generic persistence events.
+- Explicit events published from the application layer.
 
-These were rejected due to implicit behavior and limited expressiveness.
+## Decision Outcome
+
+Chosen option: "Explicit events published from the application layer", because the alternatives (JPA lifecycle callbacks, generic persistence events) were rejected due to implicit behavior and limited expressiveness.
+
+- Publish events explicitly from the application layer.
+- Do not rely on JPA entity listeners or persistence callbacks for business events.
+
+### Consequences
+
+**Positive**
+
+- Business intent is explicit and observable.
+- Cross-cutting concerns do not leak into domain or persistence layers.
+
+**Negative**
+
+- Requires discipline to publish events consistently.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+### JPA lifecycle callbacks
+
+- Bad, because of implicit behavior and limited expressiveness (rejected).
+
+### Generic persistence events
+
+- Bad, because of implicit behavior and limited expressiveness (rejected).
+
+### Explicit events published from the application layer (chosen)
+
+- Good, because business intent is explicit and observable.
+- Good, because cross-cutting concerns do not leak into domain or persistence layers.
+- Bad, because it requires discipline to publish events consistently.
+
+## Notes for AI
+
+- Event names must reflect business intent, not technical actions.
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-005__lightweight-hexagonal-architecture.md
+++ b/docs/adr/ADR-005__lightweight-hexagonal-architecture.md
@@ -1,32 +1,80 @@
 # ADR-005 — Lightweight Hexagonal Architecture (Ports & Adapters)
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-01-31
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** <!-- TODO: fill in — not stated in original ADR -->
 
-## Context
+## Context and Problem Statement
 
 As the starter grows, clear boundaries are required to prevent infrastructure leakage
 and to keep business/application logic testable and adaptable.
 
 A full-blown hexagonal architecture was considered but deemed too heavy.
 
-## Decision
+## Decision Drivers
+
+- Prevent infrastructure leakage.
+- Keep business/application logic testable and adaptable.
+- Avoid the overhead of a full-blown hexagonal architecture.
+
+## Considered Options
+
+- Traditional layered architecture.
+- Framework-centric design.
+- Full-blown hexagonal architecture.
+- Lightweight hexagonal architecture.
+
+## Decision Outcome
+
+Chosen option: "Lightweight hexagonal architecture", because the full-blown hexagonal architecture was deemed too heavy, and the traditional layered / framework-centric alternatives were rejected due to weaker boundary enforcement.
 
 - Adopt a lightweight hexagonal architecture.
 - Use inbound adapters (REST) calling inbound ports (use cases).
 - Define outbound ports as interfaces where they clarify boundaries.
 - Implement outbound adapters for persistence, auditing, and integrations.
-- Avoid unnecessary abstraction and “port explosion”.
 
-## Consequences
+### Consequences
+
+**Positive**
 
 - Clear dependency direction (adapters depend inward).
 - Improved testability and maintainability.
+
+**Negative**
+
 - Slight increase in structural complexity.
 
-## Alternatives Considered
+### Confirmation
 
-- Traditional layered architecture.
-- Framework-centric design.
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
 
-Both were rejected due to weaker boundary enforcement.
+## Pros and Cons of the Options
+
+### Traditional layered architecture
+
+- Bad, because of weaker boundary enforcement (rejected).
+
+### Framework-centric design
+
+- Bad, because of weaker boundary enforcement (rejected).
+
+### Full-blown hexagonal architecture
+
+- Bad, because it was deemed too heavy (rejected).
+
+### Lightweight hexagonal architecture (chosen)
+
+- Good, because of clear dependency direction (adapters depend inward).
+- Good, because of improved testability and maintainability.
+- Bad, because of a slight increase in structural complexity.
+
+## Notes for AI
+
+- Avoid unnecessary abstraction and "port explosion".
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-006__tenant-aware-auditing.md
+++ b/docs/adr/ADR-006__tenant-aware-auditing.md
@@ -1,36 +1,36 @@
 # ADR-006 — Domain Events & Tenant-Aware Auditing (JSON Patch, AFTER_COMMIT)
 
-**Status:** Accepted  
+**Status:** Accepted
 **Date:** 2026-02-26
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** ADR-002 (Soft Multi-Tenancy), ADR-003 (Event-Driven Auditing Architecture), ADR-004 (Application Events vs JPA Interceptors), ADR-005 (Lightweight Hexagonal Architecture)
 
----
+## Context and Problem Statement
 
-## Context
+The system requires a reliable, explicit, and decoupled auditing mechanism aligned with ADR-002, ADR-003, ADR-004, and ADR-005.
 
-The system requires a reliable, explicit, and decoupled auditing mechanism aligned with:
+## Decision Drivers
 
-- ADR-002 — Soft Multi-Tenancy
-- ADR-003 — Event-Driven Auditing Architecture
-- ADR-004 — Application Events vs JPA Interceptors
-- ADR-005 — Lightweight Hexagonal Architecture
+- Respect tenant boundaries.
+- Capture actor identity (SYSTEM vs USER).
+- Capture the delta of changes.
+- Execute only after successful transaction commit.
+- Remain fully decoupled from domain logic.
 
-Auditing must:
+## Considered Options
 
-- Respect tenant boundaries
-- Capture actor identity (SYSTEM vs USER)
-- Capture the delta of changes
-- Execute only after successful transaction commit
-- Remain fully decoupled from domain logic
+- JPA Entity Listeners.
+- Hibernate Envers.
+- Immediate synchronous audit writes.
+- Domain Events + AFTER_COMMIT auditing model.
 
----
+## Decision Outcome
 
-## Decision
+Chosen option: "Domain Events + AFTER_COMMIT auditing model".
 
-We adopt a **Domain Events + AFTER_COMMIT auditing model**.
-
----
-
-## 1. Domain Events Model
+### 1. Domain Events Model
 
 - Introduce `DomainEvent` as a sealed interface in `platform-common`.
 - Domain events must be immutable Java Records.
@@ -54,9 +54,7 @@ For update events:
 
 Events must never expose JPA entities.
 
----
-
-## 2. Event Publishing
+### 2. Event Publishing
 
 - `DomainEventPublisher` defined as an outbound port in `platform-common`.
 - Spring-based adapter implemented in `platform-web`.
@@ -66,18 +64,13 @@ Events must never expose JPA entities.
 @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 ```
 
-### Rationale
+Rationale: Audit entries must only be written if the business transaction commits successfully. No "ghost" audit entries are allowed.
 
-Audit entries must only be written if the business transaction commits successfully.  
-No "ghost" audit entries are allowed.
-
----
-
-## 3. AuditLog Model (Append-Only)
+### 3. AuditLog Model (Append-Only)
 
 Create `AuditLog` entity in `platform-data`.
 
-### Fields
+Fields:
 
 - `id` (UUID, generated in application)
 - `tenantId` (mandatory)
@@ -90,7 +83,7 @@ Create `AuditLog` entity in `platform-data`.
 - `changes` (TEXT or JSONB, storing JSON Patch)
 - `created_at` (DB default `CURRENT_TIMESTAMP`)
 
-### Rules
+Rules:
 
 - `AuditLog` is append-only.
 - No public setters.
@@ -98,32 +91,21 @@ Create `AuditLog` entity in `platform-data`.
 - Protected no-args constructor for JPA.
 - No `updated_at` required (append-only model).
 
----
-
-## 4. Actor Context
+### 4. Actor Context
 
 Introduce identity boundary:
 
 - `ActorContext` (sealed interface)
     - `SystemActor`
     - `UserActor(UUID userId)`
-
 - `ActorContextHolder` (ThreadLocal)
 
-### MVP Actor Resolution
+MVP Actor Resolution:
 
 - `X-Actor-Type: SYSTEM | USER` (missing = SYSTEM)
 - `X-Actor-Id: <uuid>` required for USER
 
-### Important
-
-- Header-based resolution is MVP only.
-- JWT-based authentication will replace it in a future iteration.
-- Headers must never be trusted in production.
-
----
-
-## 5. Architectural Constraints
+### 5. Architectural Constraints
 
 - Domain events must not depend on Spring.
 - Domain events must not depend on JPA.
@@ -131,11 +113,9 @@ Introduce identity boundary:
 - Persistence and listeners reside in outbound adapters.
 - Application layer publishes events explicitly.
 
----
+### Consequences
 
-## Consequences
-
-### Positive
+**Positive**
 
 - Clear separation of concerns.
 - Explicit business intent.
@@ -143,10 +123,44 @@ Introduce identity boundary:
 - Safe execution after commit.
 - Meaningful use of Java 21 features (sealed types, records, pattern matching).
 
-### Trade-offs
+**Negative**
 
 - Slight increase in structural complexity.
 - In-process event handling may lose audit entries in crash scenarios.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+### JPA Entity Listeners
+
+- Bad, because of implicit behavior (rejected).
+
+### Hibernate Envers
+
+- Bad, because of tight coupling to persistence model (rejected).
+
+### Immediate synchronous audit writes
+
+- Bad, because it violates transactional integrity (rejected).
+
+### Domain Events + AFTER_COMMIT auditing model (chosen)
+
+- Good, because of clear separation of concerns.
+- Good, because of explicit business intent.
+- Good, because of tenant-aware audit trail.
+- Good, because of safe execution after commit.
+- Good, because of meaningful use of Java 21 features (sealed types, records, pattern matching).
+- Bad, because of a slight increase in structural complexity.
+- Bad, because in-process event handling may lose audit entries in crash scenarios.
+
+## Notes for AI
+
+- Header-based actor resolution (`X-Actor-Type` / `X-Actor-Id`) is MVP only; JWT-based authentication will replace it in a future iteration. Headers must never be trusted in production.
+
+## More Information
 
 ### Future Consideration — Transactional Outbox
 
@@ -156,11 +170,3 @@ To guarantee at-least-once delivery in case of crashes:
 - Process events asynchronously from the outbox.
 
 **Not implemented in this ADR.**
-
----
-
-## Alternatives Considered
-
-- JPA Entity Listeners — rejected (implicit behavior).
-- Hibernate Envers — rejected (tight coupling to persistence model).
-- Immediate synchronous audit writes — rejected (violates transactional integrity).  

--- a/docs/adr/ADR-007__transactional-outbox-for-external-integration.md
+++ b/docs/adr/ADR-007__transactional-outbox-for-external-integration.md
@@ -1,14 +1,33 @@
 # ADR-007 — Transactional Outbox for External Integration
 
-**Status:** Accepted  
-**Focus:** Reliability, Eventual Consistency, Traceability  
+**Status:** Accepted
+**Date:** <!-- TODO: fill in — not stated in original ADR -->
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** ADR-002 (Soft Multi-Tenancy), ADR-006 (Domain Events & Tenant-Aware Auditing)
 
-## Context
+## Context and Problem Statement
+
+Focus: Reliability, Eventual Consistency, Traceability.
+
 Following ADR-006, we need a mechanism that guarantees "At-Least-Once" delivery of events to external systems (Kafka, SaaS APIs) without the risk of "Dual Write" inconsistencies.
 
 While `AuditLog` (ADR-006) captures **what happened** for historical purposes, we need a dedicated mechanism for **what needs to be sent** to external consumers. A failure in a network call to Kafka must not roll back the business transaction, yet we must guarantee the message won't be lost.
 
-## Decision
+## Decision Drivers
+
+- Guarantee "At-Least-Once" delivery of events to external systems (Kafka, SaaS APIs).
+- Avoid "Dual Write" inconsistencies.
+- A failure in a network call to an external system must not roll back the business transaction.
+- `tenant_id` must be mandatory and propagated to external systems (Soft Multi-tenancy — ADR-002).
+
+## Considered Options
+
+<!-- TODO: fill in — original ADR does not enumerate alternative mechanisms side by side; it only names the risk ("Dual Write" inconsistencies) that the chosen mechanism avoids -->
+
+## Decision Outcome
+
 1. **Mechanism**: Transactional Outbox Pattern. External messages are persisted in a `message_outbox` table within the same ACID transaction as the domain change.
 2. **Separation of Intent**:
     - `AuditLog`: Captures Domain Facts (e.g., `USER_EMAIL_CHANGED`).
@@ -22,7 +41,8 @@ While `AuditLog` (ADR-006) captures **what happened** for historical purposes, w
     - **Partitioning**: The `partition_key` (typically the aggregate's `entityId`) is used as the Kafka Message Key to ensure chronological ordering per entity.
 5. **Multi-tenancy**: `tenant_id` is mandatory and propagated via Kafka Headers (Soft Multi-tenancy - ADR-002).
 
-## Data Schema (DDL)
+### Data Schema (DDL)
+
 The schema follows standards: UUID v7, DB-driven timestamps, and JSONB for flexible payloads.
 
 ```sql
@@ -61,24 +81,36 @@ CREATE INDEX idx_message_outbox_origin ON message_outbox (origin_event_type);
 -- Trigger for DB-driven updated_at
 ```
 
+### Consequences
+
+**Positive**
+
+- Guaranteed message delivery, zero dual-write risk, high traceability.
+
+**Negative**
+
+- Slight eventual consistency delay, additional database storage for the outbox table.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+<!-- TODO: fill in — original ADR does not compare alternative mechanisms -->
+
+## Notes for AI
 
 **Implementation Rules**
+
 - Infrastructure: Use spring-kafka (explicit KafkaTemplate configuration).
-
 - Relay Service: A background process (@Scheduled) with ShedLock polls for PENDING records.
-
 - Batching: Fetch and process records in batches (default 100) to optimize throughput.
-
-- Visibility Buffer: Poll only records where created_at < NOW() - INTERVAL '1 second' to ensure transaction visibility.
-
+- Visibility Buffer: Poll only records where `created_at < NOW() - INTERVAL '1 second'` to ensure transaction visibility.
 - Error Handling: Implement exponential backoff or simple retry count. After 5 failed attempts, status moves to FAILED.
-
 - Retention Policy: Records with status SENT older than 7 days should be purged automatically.
-
 - Testing: Must use Testcontainers (PostgreSQL + Redpanda/Kafka) to verify the full integration chain.
 
-**Consequences**
+## More Information
 
-- Positive: Guaranteed message delivery, zero dual-write risk, high traceability.
-
-- Negative: Slight eventual consistency delay, additional database storage for the outbox table.
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-008__user-registration.md
+++ b/docs/adr/ADR-008__user-registration.md
@@ -1,14 +1,34 @@
 # ADR-008 — User Registration & Password Security
 
-**Focus:** Security, Data Integrity, Observability  
-**Context:** Implementation of the User Registration flow (ST-008) in a multi-tenant environment.
+**Status:** <!-- TODO: fill in — not stated in original ADR -->
+**Date:** <!-- TODO: fill in — not stated in original ADR -->
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
+**Related:** ADR-006 (Domain Events & Tenant-Aware Auditing)
 
-## Context
+## Context and Problem Statement
+
+Focus: Security, Data Integrity, Observability.
+
+Implementation of the User Registration flow (ST-008) in a multi-tenant environment.
+
 User registration is a critical entry point that must balance security (password protection), data integrity (no duplicates), and observability (traceability across systems). We need to define how passwords travel through the system and how we ensure identity uniqueness.
 
-## Decision
+## Decision Drivers
+
+- Security: passwords must be protected end-to-end.
+- Data integrity: no duplicate identities.
+- Observability: traceability across systems.
+
+## Considered Options
+
+<!-- TODO: fill in — original ADR does not list alternative options -->
+
+## Decision Outcome
 
 ### 1. Password Handling & Hashing
+
 - **Security Boundary**: Raw passwords are accepted ONLY in the Inbound Adapter (REST DTO) over HTTPS.
 - **Hashing Algorithm**: The Use Case layer must hash the password using **BCrypt** before creating the `User` entity.
 - **Cost Factor**: The BCrypt cost factor is set to **12**.
@@ -16,6 +36,7 @@ User registration is a critical entry point that must balance security (password
 - **Entity Safety**: The `User` JPA entity MUST NEVER hold plaintext passwords. Only `password_hash` is allowed.
 
 ### 2. Email Normalization & Uniqueness
+
 - **Normalization**: To prevent account duplication and spoofing, all emails must be converted to **lowercase** before any validation or persistence logic.
 - **Uniqueness Enforcement**:
     - Business logic will perform a "fail-fast" check using `existsByEmail`.
@@ -23,24 +44,44 @@ User registration is a critical entry point that must balance security (password
     - Race conditions resulting in DB constraint violations must be mapped to a `UserAlreadyExistsException` (HTTP 409).
 
 ### 3. Traceability (Correlation ID)
+
 - The flow must preserve the **Correlation ID** from the HTTP Request.
 - This ID must be propagated to the `UserCreatedEvent` and subsequently to the **Kafka Headers** via the Transactional Outbox. This allows end-to-end debugging of a registration triggered by a specific user request.
 
 ### 4. Event Strategy
+
 - We will reuse the generic **`UserCreatedEvent`** (as per ADR-006).
 - The `IntegrationEventListener` will listen for this event to trigger the `WELCOME_EMAIL_REQUEST` in the Outbox.
 
-## Implementation Logic Flow
-1. **Sanitize**: Trim and lowercase the email.
-2. **Validate**: Perform a tenant-aware uniqueness check.
-3. **Hash**: Execute `PasswordEncoder.encode(rawPassword)`.
-4. **Persist**: Save `User` entity to DB.
-5. **Emit**: Publish `UserCreatedEvent` (carrying the current Correlation ID).
+### Consequences
 
-## Consequences
-- **Positive**: Robust security boundary; plaintext never leaks to logs or domain; full traceability across distributed components.
-- **Negative**: Increased CPU load for BCrypt (acceptable trade-off); registration is slightly slower due to intentional hashing delay.
-- **Development**: Requires strict ArchUnit rules to ensure no plaintext password fields are added to entities.
+**Positive**
 
-## Notes
+- Robust security boundary; plaintext never leaks to logs or domain; full traceability across distributed components.
+
+**Negative**
+
+- Increased CPU load for BCrypt (acceptable trade-off); registration is slightly slower due to intentional hashing delay.
+
+### Confirmation
+
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
+
+## Pros and Cons of the Options
+
+<!-- TODO: fill in — original ADR does not list alternative options to compare -->
+
+## Notes for AI
+
+- Requires strict ArchUnit rules to ensure no plaintext password fields are added to entities.
 - Sensitive data masking must be active in all loggers to prevent DTO logging from exposing raw passwords.
+- Implementation Logic Flow:
+    1. **Sanitize**: Trim and lowercase the email.
+    2. **Validate**: Perform a tenant-aware uniqueness check.
+    3. **Hash**: Execute `PasswordEncoder.encode(rawPassword)`.
+    4. **Persist**: Save `User` entity to DB.
+    5. **Emit**: Publish `UserCreatedEvent` (carrying the current Correlation ID).
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material -->

--- a/docs/adr/ADR-009__platform-testing-infrastructure.md
+++ b/docs/adr/ADR-009__platform-testing-infrastructure.md
@@ -1,14 +1,15 @@
 # ADR-009 — Platform Testing Infrastructure (Testcontainers, Fixtures, Multi-Tenancy)
 
-**Status:** Proposed  
-**Date:** 2026-03-25  
-**Focus:** Test ergonomics, repeatable integration tests, alignment with Soft Multi-Tenancy and Outbox  
-
+**Status:** Proposed
+**Date:** 2026-03-25
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
 **Related:** ADR-002 (Soft Multi-Tenancy), ADR-005 (Lightweight Hexagonal), ADR-007 (Transactional Outbox), `.cursor/rules/40-testing.mdc`
 
----
+## Context and Problem Statement
 
-## Context
+Focus: Test ergonomics, repeatable integration tests, alignment with Soft Multi-Tenancy and Outbox.
 
 Integration tests in the starter currently duplicate **Testcontainers** setup (PostgreSQL image variants, credentials, `@DynamicPropertySource`) and **tenant bootstrap** patterns (`Tenant.create`, persistence, `TenantContextHolder`) across multiple test classes in `sample-service`.
 
@@ -22,22 +23,29 @@ The testing policy requires integration tests for persistence, multi-tenancy, an
 
 We need a **single, opinionated place** for shared test infrastructure that does **not** violate hexagonal boundaries: no domain logic from sample services in platform modules; only reusable test setup and helpers.
 
----
+## Decision Drivers
 
-## Why this refactor (value added)
-
-Refactoring integration tests into shared `platform-testing` infrastructure is not an end in itself. The expected benefits:
+Refactoring integration tests into shared `platform-testing` infrastructure is not an end in itself. The expected benefits driving this decision:
 
 1. **Single source of truth for test runtime** — One canonical Postgres image, one Kafka broker image, one mapping to Spring properties. Changing versions or broker settings happens in one module, not in every test class.
 2. **Faster forks and new services** — A new microservice adds one Gradle dependency and inherits the same stack; authors focus on business assertions, not on Docker wiring.
-3. **Less drift and fewer “works on my machine” issues** — Eliminates inconsistent image tags and credentials across tests.
+3. **Less drift and fewer "works on my machine" issues** — Eliminates inconsistent image tags and credentials across tests.
 4. **Alignment with ADR-007** — Outbox + Kafka is part of the **baseline** test stack, so full integration tests do not require a one-off Kafka setup in a single class.
-5. **Shorter feedback loops in CI** — **One shared container instance** per JVM test run (see Decision §3) reduces startup overhead compared to starting separate Postgres (and Kafka) per test class.
+5. **Shorter feedback loops in CI** — **One shared container instance** per JVM test run (see Decision Outcome §3) reduces startup overhead compared to starting separate Postgres (and Kafka) per test class.
 6. **Clearer ownership** — Test infrastructure is a **platform concern**; domain-specific fixtures and assertions remain in each service.
 
----
+## Considered Options
 
-## Decision
+- Copy-paste test setup in each service.
+- Shared test code in `platform-infrastructure`'s `test` source set.
+- Kafka optional per test class (opt-in rather than baseline).
+- Per-class `@Container` instances (new container per test class).
+- Redpanda or other Kafka-protocol-compatible images (as the default broker).
+- Dedicated `platform-testing` module with baseline Postgres + Kafka Testcontainers, single shared instance per JVM, `confluentinc/cp-kafka` as the canonical image.
+
+## Decision Outcome
+
+Chosen option: "Dedicated `platform-testing` module with baseline Postgres + Kafka Testcontainers, single shared instance per JVM, `confluentinc/cp-kafka` as the canonical image."
 
 ### 1. New module: `platform-testing`
 
@@ -56,7 +64,7 @@ Refactoring integration tests into shared `platform-testing` infrastructure is n
 - **Lifecycle:** **One instance** of each container (singleton) for the **entire test JVM process** (Gradle `test` task), shared across test classes. Implementation detail: static container fields started once, with `spring.datasource.*` and `spring.kafka.bootstrap-servers` registered via `@DynamicPropertySource` on a small number of abstract base classes (or a single entry point), so that all inheriting tests reuse the same brokers.
 - **Dynamic property registration:** Map container endpoints to `spring.datasource.*` and `spring.kafka.bootstrap-servers` (and any other required Kafka client properties for tests).
 
-### 3a. Implications of including Kafka in the baseline
+#### 3a. Implications of including Kafka in the baseline
 
 | Area | Implication |
 |------|-------------|
@@ -64,22 +72,22 @@ Refactoring integration tests into shared `platform-testing` infrastructure is n
 | **Resources** | Higher memory and CPU footprint during `./gradlew test` (Kafka broker + Zookeeper-less or KRaft image per chosen image). |
 | **Duration** | First cold start of the Kafka image is slower; **singleton** reuse amortizes this across many test classes. |
 | **Stability** | Flakiness risk if tests share topics without isolation (see mitigation below). |
-| **Mitigation (tests)** | Use **unique topic names** per test or per class (prefix + UUID), or clear consumer groups / seek strategies as today in `OutboxIntegrationTest`, so parallel or sequential tests do not read each other’s messages. |
+| **Mitigation (tests)** | Use **unique topic names** per test or per class (prefix + UUID), or clear consumer groups / seek strategies as today in `OutboxIntegrationTest`, so parallel or sequential tests do not read each other's messages. |
 | **Gradle** | `platform-testing` test-fixtures depend on `testcontainers-kafka` (and Postgres) explicitly; consumers inherit them transitively. |
 
-### 3b. Canonical Docker images
+#### 3b. Canonical Docker images
 
 - **PostgreSQL:** Single canonical tag for all integration tests (e.g. `postgres:15`); migrate away from ad-hoc variants (`postgres:15-alpine`, different DB names) in favor of one definition in `platform-testing`.
 - **Kafka (broker):** **`confluentinc/cp-kafka`** — Confluent Platform packaging of Apache Kafka, aligned with common production setups and with the existing outbox integration test pattern.
-  - **Baseline tag:** `7.5.0` (must match the shared `DockerImageName` used in `AbstractIntegrationTest` / test-fixtures). Version bumps are done **only** in `platform-testing`, not per test class.
-  - **Testcontainers usage:** `new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))` (or equivalent factory in one place).
+    - **Baseline tag:** `7.5.0` (must match the shared `DockerImageName` used in `AbstractIntegrationTest` / test-fixtures). Version bumps are done **only** in `platform-testing`, not per test class.
+    - **Testcontainers usage:** `new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))` (or equivalent factory in one place).
 - **Rationale:** Avoids Redpanda/Kafka-API-compatible brokers for the **default** stack so integration tests exercise a **real Kafka broker** behavior consistent with ADR-007; trade-off is heavier CI cost (accepted in §3a).
 
-### 4. Tenant fixtures (no “context on demand” in scope)
+### 4. Tenant fixtures (no "context on demand" in scope)
 
 - Provide helpers to **persist** a `Tenant` (from `platform-data`) and return **`UUID tenantId`**, matching patterns already used in integration tests.
-- **Out of scope for `platform-testing` v1:** Helpers that wrap `TenantContextHolder` / `CorrelationContextHolder` in a “run with context” API.
-- **Rationale:** Existing tests already set and clear context **explicitly** in `@BeforeEach` / `@AfterEach`. That remains **visible and grep-friendly** in each test class. A runner API would save a few lines but adds indirection and makes it harder to see when context leaks (especially with correlation). If repetition becomes painful later, a thin optional helper can be added **without** changing this ADR’s core decision.
+- **Out of scope for `platform-testing` v1:** Helpers that wrap `TenantContextHolder` / `CorrelationContextHolder` in a "run with context" API.
+- **Rationale:** Existing tests already set and clear context **explicitly** in `@BeforeEach` / `@AfterEach`. That remains **visible and grep-friendly** in each test class. A runner API would save a few lines but adds indirection and makes it harder to see when context leaks (especially with correlation). If repetition becomes painful later, a thin optional helper can be added **without** changing this ADR's core decision.
 
 ### 5. Tenant isolation helpers
 
@@ -87,7 +95,7 @@ Refactoring integration tests into shared `platform-testing` infrastructure is n
 
 ### 6. Outbox testing helpers
 
-- Generic helpers or assertions for **outbox table** state (e.g. `PENDING` rows, headers in JSONB) **where** they do not depend on a specific message type from a single service. Service-specific message types and assertions stay in the service’s tests.
+- Generic helpers or assertions for **outbox table** state (e.g. `PENDING` rows, headers in JSONB) **where** they do not depend on a specific message type from a single service. Service-specific message types and assertions stay in the service's tests.
 
 ### 7. Refactor of existing tests: equivalence guarantee
 
@@ -100,9 +108,7 @@ Refactoring integration tests into shared `platform-testing` infrastructure is n
 - Add a pointer in **`architecture.md`** (Documentation Index / Testing) to this ADR once the module is in place.
 - **ArchUnit** (optional follow-up): Rule discouraging ad-hoc `@Container` PostgreSQL/Kafka in service tests in favor of the shared base—only if it does not block legitimate exceptions.
 
----
-
-## Module and package layout (ASCII)
+### Module and package layout (ASCII)
 
 ```
 platform-testing/
@@ -130,9 +136,7 @@ sample-service/
 │   └── *.java                 # extends AbstractIntegrationTest; uses TenantTestFixtures; no local @Container
 ```
 
----
-
-## Consequences
+### Consequences
 
 **Positive**
 
@@ -148,19 +152,47 @@ sample-service/
 - **CI:** Slightly heavier integration test runs (Kafka always on).
 - Helpers must stay **generic**; domain-specific test data stays in services.
 
----
+### Confirmation
 
-## Alternatives Considered
+- Status is set to **Accepted** once `platform-testing` exists, at least one reference test uses it, and **migration equivalence** has been verified for migrated classes.
 
-1. **Copy-paste only in each service** — Rejected: duplication already exists and will grow.
-2. **Shared test code in `platform-infrastructure` `test` source** — Rejected: not consumable across modules.
-3. **Kafka optional per test class** — Rejected for this ADR: baseline includes Kafka for **consistency** with ADR-007; tests that do not need broker interaction still run against the same stack (no second code path for “DB-only” images).
-4. **Per-class `@Container` instances** — Rejected in favor of **one instance per JVM** for performance and consistency.
-5. **Redpanda or other Kafka-protocol-compatible images** — Rejected for the **default** baseline: we standardize on **`confluentinc/cp-kafka`** for parity with typical Kafka deployments; faster-but-different brokers remain a possible future profile, not the starter default.
+## Pros and Cons of the Options
 
----
+### Copy-paste test setup in each service
 
-## Notes
+- Bad, because duplication already exists and will grow (rejected).
 
-- **Migration:** Refactor `sample-service` integration tests incrementally; after each step, **same assertions** as before (see §7).
-- **Status:** Set to **Accepted** once `platform-testing` exists, at least one reference test uses it, and **migration equivalence** has been verified for migrated classes.
+### Shared test code in `platform-infrastructure`'s `test` source set
+
+- Bad, because it is not consumable across modules (rejected).
+
+### Kafka optional per test class
+
+- Bad, because it breaks consistency with ADR-007 and would require a second "DB-only" code path (rejected for this ADR).
+
+### Per-class `@Container` instances
+
+- Bad, because a single instance per JVM performs better and is more consistent (rejected in favor of one instance per JVM).
+
+### Redpanda or other Kafka-protocol-compatible images
+
+- Bad, because the default baseline standardizes on `confluentinc/cp-kafka` for parity with typical Kafka deployments (rejected as the default; a faster-but-different broker remains a possible future profile).
+
+### Dedicated `platform-testing` module (chosen)
+
+- Good, because of one place to update Postgres/Kafka images and Spring properties.
+- Good, because singleton containers reduce startup cost versus per-class containers.
+- Good, because baseline Kafka matches ADR-007 outbox verification without bespoke setup per class.
+- Good, because the explicit equivalence rule keeps the refactor safe and reviewable.
+- Bad, because it is an extra module to maintain.
+- Bad, because test-fixtures wiring must be kept clean of runtime classpaths.
+- Bad, because CI integration test runs are slightly heavier (Kafka always on).
+- Bad, because helpers must stay generic; domain-specific test data stays in services.
+
+## Notes for AI
+
+- **Migration:** Refactor `sample-service` integration tests incrementally; after each step, verify the **same assertions** as before (see Decision Outcome §7).
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material beyond the Related ADRs and rule file already listed above -->

--- a/docs/adr/ADR-010__observability-and-telemetry-baseline.md
+++ b/docs/adr/ADR-010__observability-and-telemetry-baseline.md
@@ -1,60 +1,114 @@
 # ADR-010 — Observability & Telemetry Baseline (Metrics, Tracing, Structured Logging)
 
-**Focus:** Production Readiness, Observability, Operations  
+**Status:** <!-- TODO: fill in — not stated in original ADR -->
+**Date:** <!-- TODO: fill in — not stated in original ADR -->
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
 **Related:** ADR-002 (Soft Multi-Tenancy), ADR-005 (Lightweight Hexagonal Architecture), ADR-006 (Tenant-Aware Auditing), ADR-007 (Transactional Outbox)
 
-## Context
+## Context and Problem Statement
+
+Focus: Production Readiness, Observability, Operations.
 
 Microservices generated from this starter must be "Day 2 Operations" ready out-of-the-box. This requires a standardized approach to application health monitoring, metrics collection, and distributed tracing.
 
 Given our architectural decisions regarding event-driven auditing (ADR-006), transactional outbox (ADR-007), and soft multi-tenancy (ADR-002), it is crucial that every log entry and metric in the system carries the appropriate context (specifically, the tenant and actor identity). Manual propagation of this context is error-prone and pollutes business logic. We need a centralized, infrastructure-level mechanism to handle observability without leaking into the pure Domain layer.
 
-## Decision
+## Decision Drivers
 
-We adopt a standardized observability stack based on the Spring Boot 3 / Micrometer ecosystem:
+- Standardized health monitoring, metrics collection, and distributed tracing ("Day 2 Operations" readiness).
+- Every log entry and metric must carry tenant and actor identity context (aligned with ADR-002, ADR-006).
+- Manual propagation of this context is error-prone and pollutes business logic.
+- Observability must not leak into the pure Domain layer.
+
+## Considered Options
+
+- Spring Cloud Sleuth for Tracing.
+- Infrastructure-level Agents Only (e.g., Datadog/New Relic Java Agents).
+- No Structured Logging (Plain Text everywhere).
+- Standardized observability stack based on Spring Boot 3 / Micrometer ecosystem.
+
+## Decision Outcome
+
+Chosen option: "Standardized observability stack based on Spring Boot 3 / Micrometer ecosystem."
 
 ### 1. Health & Metrics (Actuator Baseline)
+
 - We enable Spring Boot Actuator endpoints: `/actuator/health/liveness`, `/actuator/health/readiness` (for Kubernetes/orchestrator probes), and `/actuator/prometheus` (for metric scraping).
 - To prevent infrastructure data leaks, Actuator endpoints must be secured or exposed on a separate management port (e.g., `management.server.port=8081`).
 
 ### 2. Distributed Tracing
+
 - We adopt `micrometer-tracing` (using the W3C Trace Context standard).
 - A unique `traceId` and `spanId` must be automatically generated for every incoming HTTP request and propagated to downstream systems or message brokers (Kafka).
 
 ### 3. Structured Logging (JSON) & Context Enrichment (MDC)
+
 - **Format:** We adopt `logstash-logback-encoder` to output logs in structured JSON format. This is mandatory for the `production` profile to allow easy parsing by log aggregators (ELK, Datadog). The `local` profile will retain human-readable plain text console logs.
 - **MDC Enrichment:** We mandate the automatic injection of architectural context into the Mapped Diagnostic Context (MDC). Every log entry must include `tenant_id`, `actor_id`, and `trace_id`.
 
-## Consequences
+### Consequences
 
-### Positive
+**Positive**
+
 - **Out-of-the-box Production Readiness:** Immediate compatibility with standard monitoring stacks (Prometheus, Grafana, ELK).
 - **Faster Debugging:** Full log correlation via `traceId` across synchronous API calls and asynchronous Kafka events.
 - **Tenant-Isolated Telemetry:** Platform operators can easily filter logs and metrics by `tenant_id` to diagnose customer-specific issues.
 - **Domain Purity:** Observability concerns are pushed to the edge (Inbound/Outbound Adapters), keeping the Domain entirely agnostic of logging frameworks and metrics registries.
 
-### Trade-offs / Negative
+**Negative**
+
 - **Dependency Bloat:** Adds several dependencies to `build.gradle` (Actuator, Micrometer Tracing, Logstash Encoder).
 - **Performance Overhead:** Slight CPU/Memory overhead for JSON serialization in logs and trace generation (acceptable for most business applications).
 
-## Alternatives Considered
+### Confirmation
 
-1. **Spring Cloud Sleuth for Tracing** *Rejected:* Sleuth is officially deprecated in Spring Boot 3.x. Micrometer Tracing is the modern, native replacement.
-2. **Infrastructure-level Agents Only (e.g., Datadog/New Relic Java Agents)** *Rejected:* While powerful, relying solely on proprietary agents makes local development and open-source observability (like local Zipkin/Jaeger or Prometheus) harder. Baking Micrometer into the application makes the starter vendor-agnostic.
-3. **No Structured Logging (Plain Text everywhere)** *Rejected:* Plain text logs require complex Grok parsing rules on the infrastructure side (Logstash/Fluentd) to extract `trace_id` and `tenant_id`. Emitting JSON directly from the application guarantees reliable parsing and immediate observability.
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
 
-## Notes & Implementation Guidelines (For AI Assistants / Cursor)
+## Pros and Cons of the Options
+
+### Spring Cloud Sleuth for Tracing
+
+- Bad, because Sleuth is officially deprecated in Spring Boot 3.x (rejected).
+
+### Infrastructure-level Agents Only (e.g., Datadog/New Relic Java Agents)
+
+- Bad, because relying solely on proprietary agents makes local development and open-source observability (like local Zipkin/Jaeger or Prometheus) harder (rejected).
+
+### No Structured Logging (Plain Text everywhere)
+
+- Bad, because plain text logs require complex Grok parsing rules on the infrastructure side (Logstash/Fluentd) to extract `trace_id` and `tenant_id` (rejected).
+
+### Standardized observability stack based on Spring Boot 3 / Micrometer ecosystem (chosen)
+
+- Good, because of out-of-the-box production readiness (immediate compatibility with Prometheus, Grafana, ELK).
+- Good, because of faster debugging via full log correlation (`traceId`) across synchronous and asynchronous flows.
+- Good, because of tenant-isolated telemetry (filter logs/metrics by `tenant_id`).
+- Good, because it keeps the Domain entirely agnostic of logging frameworks and metrics registries.
+- Bad, because it adds dependency bloat (Actuator, Micrometer Tracing, Logstash Encoder).
+- Bad, because of slight CPU/Memory overhead for JSON serialization in logs and trace generation.
+
+## Notes for AI
 
 When implementing or scaffolding features based on this ADR, the AI must adhere strictly to these steps:
 
-1. **Dependency Management:** - Add `spring-boot-starter-actuator`.
+1. **Dependency Management:**
+    - Add `spring-boot-starter-actuator`.
     - Add `micrometer-registry-prometheus`.
     - Add `micrometer-tracing-bridge-brave` (or OpenTelemetry equivalent).
     - Add `net.logstash.logback:logstash-logback-encoder`.
-2. **Logback Configuration:** - Create a `logback-spring.xml` file.
+2. **Logback Configuration:**
+    - Create a `logback-spring.xml` file.
     - Define a `console` appender (plain text) for the `local`/`dev` Spring profiles.
     - Define a `json` appender using `LogstashEncoder` for the `prod` profile. Ensure MDC fields (`tenant_id`, `trace_id`, `actor_id`) are explicitly included in the JSON output.
-3. **MDC Web Filter:** - In the `platform-web` module (Inbound Adapter), create a `Filter` (e.g., `TelemetryContextFilter`).
+3. **MDC Web Filter:**
+    - In the `platform-web` module (Inbound Adapter), create a `Filter` (e.g., `TelemetryContextFilter`).
     - This filter must extract the current tenant and actor from the `ActorContextHolder` (defined in ADR-006) and put them into the `MDC` (using keys `tenant_id` and `actor_id`).
     - Ensure the MDC is properly cleared in a `finally` block to prevent thread-pool contamination.
-4. **Hexagonal Constraints:** - Never use `MDC.put()` or Micrometer classes inside the pure Domain layer. If the Domain needs to report a metric, it should publish a `DomainEvent`, which an Outbound Adapter will translate into a Micrometer metric increment.
+4. **Hexagonal Constraints:**
+    - Never use `MDC.put()` or Micrometer classes inside the pure Domain layer. If the Domain needs to report a metric, it should publish a `DomainEvent`, which an Outbound Adapter will translate into a Micrometer metric increment.
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material beyond the Related ADRs already listed above -->

--- a/docs/adr/ADR-011__api-design-and-error-handling.md
+++ b/docs/adr/ADR-011__api-design-and-error-handling.md
@@ -1,55 +1,102 @@
 # ADR-011 — API Contract & Error Handling (RFC 7807, OpenAPI)
 
-**Focus:** Developer Experience (DX), Client Integration, API Standardization  
+**Status:** <!-- TODO: fill in — not stated in original ADR -->
+**Date:** <!-- TODO: fill in — not stated in original ADR -->
+**Decision-makers:** <!-- TODO: fill in — not stated in original ADR -->
+**Consulted:** <!-- TODO: fill in — not stated in original ADR -->
+**Informed:** <!-- TODO: fill in — not stated in original ADR -->
 **Related:** ADR-005 (Lightweight Hexagonal Architecture), ADR-010 (Observability & Telemetry Baseline)
 
-## Context
+## Context and Problem Statement
+
+Focus: Developer Experience (DX), Client Integration, API Standardization.
 
 As an opinionated microservice starter, this project must provide a predictable and standardized way for external clients (frontends, mobile apps, or other microservices) to interact with its APIs and handle errors.
 
 Without a strict convention, developers tend to invent custom JSON error structures and rely on out-of-date wiki pages for API documentation. Furthermore, because we enforce a strict Lightweight Hexagonal Architecture (ADR-005), we must ensure that infrastructural HTTP concerns do not leak into our pure Domain or Use Case layers.
 
 We need a baseline for:
+
 1. **API Documentation:** Automatically generated, standard-compliant, and easy to explore.
 2. **Error Contracts:** A globally consistent JSON structure for HTTP errors that provides enough context for debugging (integrating with the tracing introduced in ADR-010).
 
-## Decision
+## Decision Drivers
 
-We adopt a standardized API contract and error-handling baseline using Spring Boot 3 capabilities and OpenAPI:
+- Provide a predictable, standardized way for external clients to interact with the API and handle errors.
+- Avoid custom JSON error structures and out-of-date wiki-based API documentation.
+- Keep infrastructural HTTP concerns out of the pure Domain and Use Case layers (ADR-005).
+- Provide enough error context for debugging, integrating with tracing (ADR-010).
+
+## Considered Options
+
+- Custom JSON Error Format.
+- Contract-First OpenAPI (writing `.yaml` first, generating Java code).
+- `@ResponseStatus` on Domain Exceptions.
+- Problem Details for HTTP APIs (RFC 7807) + Code-First OpenAPI.
+
+## Decision Outcome
+
+Chosen option: "Problem Details for HTTP APIs (RFC 7807) + Code-First OpenAPI."
 
 ### 1. Standard Error Responses (RFC 7807)
+
 - We adopt **Problem Details for HTTP APIs (RFC 7807)** as the single, global format for all API errors.
 - We will leverage Spring Boot 3's built-in support (`spring.mvc.problem-details.enabled=true`).
 - **Traceability:** Every Problem Detail response must include the `traceId` (from Micrometer/MDC) to allow clients to report exact failure identifiers.
 
 ### 2. API Documentation (OpenAPI 3.0)
+
 - We adopt the **Code-First OpenAPI** approach using `springdoc-openapi-starter-webmvc-ui`.
 - The Swagger UI will be exposed locally and in non-production environments to facilitate rapid frontend integration and manual testing.
 
 ### 3. Hexagonal Architecture Constraints (Strict Rules)
+
 - **Domain Purity:** Domain exceptions (e.g., `UserNotFoundException`, `InvalidTenantOperationException`) MUST NOT contain any Spring Web annotations (such as `@ResponseStatus`).
 - **Adapter Responsibility:** The mapping between Domain Exceptions and HTTP Status Codes must happen exclusively in the Inbound Web Adapter layer.
 - **API Annotations:** Swagger/OpenAPI annotations (`@Tag`, `@Operation`, `@Schema`) are allowed **ONLY** on REST Controllers and Request/Response DTOs within the web adapter layer. They must never appear on Domain Entities or Use Case (Inbound Port) interfaces.
 
-## Consequences
+### Consequences
 
-### Positive
+**Positive**
+
 - **Predictable Client Integrations:** Frontend teams and API consumers always know what error structure to expect.
 - **Automated Sync:** API documentation is always in sync with the actual code (Code-First approach).
 - **Clean Architecture Maintained:** The core domain remains agnostic of the web delivery mechanism (HTTP/REST).
 - **Better Debugging:** Including `traceId` in the API error response significantly reduces Mean Time To Resolution (MTTR) when users report bugs.
 
-### Trade-offs / Negative
+**Negative**
+
 - **Controller Clutter:** Swagger annotations can make the Inbound Adapter layer visually noisy.
 - **Mapping Boilerplate:** Developers must explicitly map domain exceptions to Problem Details in a global exception handler rather than simply annotating the exceptions.
 
-## Alternatives Considered
+### Confirmation
 
-1. **Custom JSON Error Format** *Rejected:* Historically common (e.g., `{ "errorMessage": "...", "errorCode": 123 }`), but forces every client to write custom parsing logic for our specific starter. RFC 7807 is an IETF standard natively supported by Spring Boot 3, providing immediate interoperability.
-2. **Contract-First OpenAPI (Writing .yaml first, generating Java code)** *Rejected:* While Contract-First is arguably better for cross-team API design, it introduces a steeper learning curve and heavy build-plugin complexity (e.g., OpenAPI Generator Maven/Gradle plugins). For a lightweight microservice starter, the Code-First approach (annotations) offers a much better Developer Experience (DX) and faster iteration speed.
-3. **@ResponseStatus on Domain Exceptions** *Rejected:* Extremely common in Spring Boot tutorials, but directly violates our Lightweight Hexagonal Architecture (ADR-005). The Domain must not know about HTTP.
+<!-- TODO: fill in — original ADR does not describe a confirmation/verification mechanism -->
 
-## Notes & Implementation Guidelines (For AI Assistants / Cursor)
+## Pros and Cons of the Options
+
+### Custom JSON Error Format
+
+- Bad, because it forces every client to write custom parsing logic for our specific starter (rejected). Historically common (e.g., `{ "errorMessage": "...", "errorCode": 123 }`), whereas RFC 7807 is an IETF standard natively supported by Spring Boot 3, providing immediate interoperability.
+
+### Contract-First OpenAPI (Writing `.yaml` first, generating Java code)
+
+- Bad, because it introduces a steeper learning curve and heavy build-plugin complexity (e.g., OpenAPI Generator Maven/Gradle plugins) (rejected). Arguably better for cross-team API design, but for a lightweight microservice starter the Code-First approach offers a much better Developer Experience (DX) and faster iteration speed.
+
+### `@ResponseStatus` on Domain Exceptions
+
+- Bad, because it directly violates the Lightweight Hexagonal Architecture (ADR-005) — the Domain must not know about HTTP (rejected). Extremely common in Spring Boot tutorials, but not compatible with this project's architecture.
+
+### Problem Details for HTTP APIs (RFC 7807) + Code-First OpenAPI (chosen)
+
+- Good, because of predictable client integrations (frontend teams and API consumers always know what error structure to expect).
+- Good, because API documentation is always automatically kept in sync with the actual code (Code-First approach).
+- Good, because the core domain remains agnostic of the web delivery mechanism (HTTP/REST).
+- Good, because including `traceId` in the API error response significantly reduces Mean Time To Resolution (MTTR).
+- Bad, because Swagger annotations can make the Inbound Adapter layer visually noisy.
+- Bad, because developers must explicitly map domain exceptions to Problem Details in a global exception handler rather than simply annotating the exceptions.
+
+## Notes for AI
 
 When implementing or scaffolding features based on this ADR, the AI must adhere to the following steps:
 
@@ -58,3 +105,7 @@ When implementing or scaffolding features based on this ADR, the AI must adhere 
 3. **Exception Mapping:** Implement `@ExceptionHandler` methods that catch specific Domain Exceptions and return Spring's `ProblemDetail` object.
 4. **TraceId Injection:** Extend the `ProblemDetail` generation to automatically inject the current `traceId` from the Tracer/MDC context into the `ProblemDetail` properties map (e.g., `problemDetail.setProperty("traceId", currentTraceId)`).
 5. **Validation:** Ensure that `MethodArgumentNotValidException` (DTO validation errors) are also mapped into RFC 7807 format, including specific field errors in the `properties` map.
+
+## More Information
+
+<!-- TODO: fill in — original ADR does not reference further material beyond the Related ADRs already listed above -->


### PR DESCRIPTION
## Summary

- Migrates ADR-001 and ADR-003 through ADR-011 to the canonical ADR template defined in `CLAUDE.md` § "45 — ADR Policy" (Context and Problem Statement, Decision Drivers, Considered Options, Decision Outcome + Consequences/Confirmation, Pros and Cons of the Options, Notes for AI, More Information), following the `adr-format` skill's migration protocol.
- Original decision content is preserved exactly — only the structure changes. Implementation-detail bullets that read as conventions/gotchas for a coding agent (e.g. MVP header-auth caveats, outbox relay implementation rules, structured-logging scaffolding steps) were moved into `## Notes for AI` rather than duplicated under `Decision`.
- Sections with no supporting material in the original ADR (e.g. `Decision-makers`, `Confirmation`, `Considered Options` where no alternatives were listed) are left as `<!-- TODO: fill in — ... -->` placeholders rather than fabricated.
- ADR-002 was already migrated and is left untouched.
- File names and ADR numbers are unchanged; this is a `DOCS_ONLY` change with no production code touched.

## Test plan

- [x] `DOCS_ONLY` change — no tests required per CLAUDE.md § "40 — Testing Policy".
- [ ] Reviewer: spot-check that each ADR's decision content still reads the same as before, just reorganized.
- [ ] Reviewer: confirm `TODO` placeholders are only used where the original ADR genuinely lacked the information (no fabricated rationale).

Made with [Cursor](https://cursor.com)